### PR TITLE
Add Deployed versions + New Services

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -612,6 +612,22 @@ service:
       josn: data.system.info.currentVersion
 ```
 
+## smallstep/certificates
+Source: https://github.com/smallstep/certificates
+```yaml
+  smallstep/certificates:
+    type: github
+    url: smallstep/certificates
+    url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    web_url: https://github.com/smallstep/certificates/releases/tag/v{{ version }}
+    icon: https://github.com/smallstep/docs/raw/main/static/graphics/logo-icon-white.svg
+    deployed_version:
+      url: https://certificates.example.io/version
+      json: version
+```
+
 ## thanos-io/thanos
 Source: https://github.com/thanos-io/thanos
 ```yaml

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -337,37 +337,6 @@ service:
       json: version
 ```
 
-## matrix-org/synapse
-Source: https://github.com/matrix-org/synapse
-```yaml
-service:
-  matrix-org/synapse:
-    type: github
-    url: matrix-org/synapse
-    url_commands:
-      - type: regex
-        regex: v([0-9.]+)$
-    web_url: https://github.com/matrix-org/synapse/releases/tag/v{{ version }}
-    icon: https://github.com/matrix-org/synapse/raw/develop/docs/favicon.svg
-    deployed_version:
-      url: https://matrix.example.io/_synapse/admin/v1/server_version
-      json: server_version
-```
-
-## release-argus/argus
-Source: https://github.com/release-argus/Argus
-```yaml
-service:
-  release-argus/argus:
-    type: github
-    url: release-argus/argus
-    web_url: https://github.com/release-argus/Argus/blob/master/CHANGELOG.md
-    icon: https://github.com/release-argus/Argus/raw/master/web/ui/static/favicon.svg
-    deployed_version:
-      url: https://argus.example.io/api/v1/version
-      json: version
-```
-
 ## louislam/uptime-kuma
 Source: https://github.com/louislam/uptime-kuma
 ```yaml
@@ -416,6 +385,23 @@ service:
     deployed_version:
       url: https://matomo.example.io/index.php?module=API&method=API.getMatomoVersion&format=JSON&force_api_session=1&token_auth=<TOKEN>
       json: value
+```
+
+## matrix-org/synapse
+Source: https://github.com/matrix-org/synapse
+```yaml
+service:
+  matrix-org/synapse:
+    type: github
+    url: matrix-org/synapse
+    url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    web_url: https://github.com/matrix-org/synapse/releases/tag/v{{ version }}
+    icon: https://github.com/matrix-org/synapse/raw/develop/docs/favicon.svg
+    deployed_version:
+      url: https://matrix.example.io/_synapse/admin/v1/server_version
+      json: server_version
 ```
 
 ## mattermost/mattermost-server
@@ -606,6 +592,20 @@ service:
         password: <password>
       json: value
       regex: v([0-9.]+)
+```
+
+## release-argus/argus
+Source: https://github.com/release-argus/Argus
+```yaml
+service:
+  release-argus/argus:
+    type: github
+    url: release-argus/argus
+    web_url: https://github.com/release-argus/Argus/blob/master/CHANGELOG.md
+    icon: https://github.com/release-argus/Argus/raw/master/web/ui/static/favicon.svg
+    deployed_version:
+      url: https://argus.example.io/api/v1/version
+      json: version
 ```
 
 ## requarks/wiki

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -320,6 +320,22 @@ service:
         - key: Authorization
           value: Bearer <API_TOKEN>
 ```
+## influxdata/influxdb
+Source: https://github.com/influxdata/influxdb
+```yaml
+service:
+  influxdata/influxdb:
+    type: github
+    url: influxdata/influxdb
+    url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    web_url: https://github.com/influxdata/influxdb/releases/tag/v{{ version }}
+    icon: https://github.com/influxdata/ui/raw/master/src/writeData/graphics/influxdb.svg
+    deployed_version:
+      url: https://influxdb.example.io/health
+      json: version
+```
 
 ## matrix-org/synapse
 Source: https://github.com/matrix-org/synapse
@@ -481,6 +497,7 @@ service:
 ## opnsense/core
 Source: https://github.com/opnsense/core
 ```yaml
+service:
   opnsense/core:
     type: url
     url: https://github.com/opnsense/core/tags
@@ -615,6 +632,7 @@ service:
 ## smallstep/certificates
 Source: https://github.com/smallstep/certificates
 ```yaml
+service:
   smallstep/certificates:
     type: github
     url: smallstep/certificates

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -478,6 +478,26 @@ service:
     icon: https://raw.githubusercontent.com/opencve/opencve/master/opencve/static/img/logo_white.png
 ```
 
+## opnsense/core
+Source: https://github.com/opnsense/core
+```yaml
+  opnsense/core:
+    type: url
+    url: https://github.com/opnsense/core/tags
+    url_commands:
+      - type: regex
+        regex: \/releases\/tag\/([0-9.]+)\"
+    web_url: https://docs.opnsense.org/CE_releases.html
+    icon: https://github.com/opnsense/core/raw/master/src/opnsense/www/themes/opnsense/build/images/icon-logo.svg
+    deployed_version:
+      url: https://opnsense.example.io/api/core/firmware/status
+      basic_auth:
+        username: <API Key>
+        password: <API Secret>
+      json: product.product_version
+      regex: ([0-9.]+)
+```
+
 ## pterodactyl/panel
 Source: https://github.com/pterodactyl/panel
 ```yaml

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -693,6 +693,23 @@ service:
     icon: https://raw.githubusercontent.com/wekan/wekan/df54863e7243b0b067ec2d30d8352ff1838931c4/meta/icons/wekan-150.svg
 ```
 
+## wordpress/wordpress
+Source: https://github.com/WordPress/WordPress
+```yaml
+service:
+  wordpress/wordpress:
+    type: url
+    url: https://github.com/wordpress/wordpress/tags
+    url_commands:
+      - type: regex_submatch
+        regex: \/releases\/tag\/([0-9.]+)\"
+    web_url: https://wordpress.org/news/category/releases/
+    icon: https://github.com/WordPress/WordPress/raw/master/wp-admin/images/wordpress-logo.svg
+    deployed_version:
+      url: https://wordpress.example.io/feed/
+      regex: '<generator>https:\/\/wordpress\.org\/\?v=([0-9.]*)\<\/generator\>'
+```
+
 ## wowchemy/wowchemy-hugo-themes
 Source: https://github.com/wowchemy/wowchemy-hugo-themes
 ```yaml

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -17,6 +17,20 @@ service:
     icon: https://raw.githubusercontent.com/adnanh/webhook/development/docs/logo/logo-128x128.png
 ```
 
+## ansible/awx
+Source: https://github.com/ansible/awx
+```yaml
+service:
+  ansible/awx:
+    type: github
+    url: ansible/awx
+    web_url: https://github.com/ansible/awx/releases/{{ version }}
+    icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
+    deployed_version:
+      url: https://awx.example.io/api/v2/ping/?format=json
+      json: version
+```
+
 ## ansible/awx-operator
 Source: https://github.com/ansible/awx-operator
 ```yaml
@@ -26,9 +40,6 @@ service:
     url: ansible/awx-operator
     web_url: https://github.com/ansible/awx-operator/releases/{{ version }}
     icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
-    deployed_version:
-      url: https://awx.example.io/api/v2/ping/
-      json: version
 ```
 
 ## dani-garcia/vaultwarden

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -322,6 +322,9 @@ service:
         regex: v([0-9.]+)$
     web_url: https://github.com/matrix-org/synapse/releases/tag/v{{ version }}
     icon: https://github.com/matrix-org/synapse/raw/develop/docs/favicon.svg
+    deployed_version:
+      url: https://matrix.example.io/_synapse/admin/v1/server_version
+      json: server_version
 ```
 
 ## release-argus/argus

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -426,8 +426,8 @@ service:
     web_url: https://github.com/netbox-community/netbox/releases/tag/v{{ version }}
     icon: https://github.com/netbox-community/netbox/raw/develop/netbox/project-static/img/netbox_icon.svg
     deployed_version:
-      url: https://netbox.example.io/
-      regex: '[0-9a-z]+ \(v([0-9.]+)\)'
+      url: https://netbox.example.io/api/status/
+      json: netbox-version
 ```
 
 ## nextcloud/server

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -26,6 +26,9 @@ service:
     url: ansible/awx-operator
     web_url: https://github.com/ansible/awx-operator/releases/{{ version }}
     icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
+    deployed_version:
+      url: https://awx.example.io/api/v2/ping/
+      json: version
 ```
 
 ## dani-garcia/vaultwarden


### PR DESCRIPTION
Add deployed_verion to `synapse` and `awx`.
Update the deployed_version for `netbox` from regex to an API call.

The `awx` integration is untested (based on the [docs](https://docs.ansible.com/ansible-tower/latest/html/towerapi/api_ref.html#/System_Configuration/System_Configuration_ping_list)) as I am not running `awx`. 
Can anyone test it with a real instance?

Added [opnsene/core](https://github.com/opnsense/core)