### PR TITLE
Fix healthchecks/healthchecks

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -263,6 +263,7 @@ service:
       - type: regex_submatch
         regex: v([0-9.]+)$
     web_url: https://github.com/healthchecks/healthchecks/releases/tag/{{ version }}
+    semantic_versioning: false
     icon: https://healthchecks.io/static/img/logo-rounded.svg
     deployed_version:
       url: https://healthchecks.example.io/docs/


### PR DESCRIPTION
Add `semantic_versioning: false` to `healthchecks/healthchecks` else the newest Release v2.1 is not detected as latest version.