### PR TITLE
Fixed wiki.js typo

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -638,7 +638,7 @@ service:
       headers:
         - key: Authorization
           value: Bearer <TOKEN>
-      josn: data.system.info.currentVersion
+      json: data.system.info.currentVersion
 ```
 
 ## smallstep/certificates


### PR DESCRIPTION
Changed "josn" to "json" i wiki.js example