### PR TITLE
Add `argoproj/argo-cd` service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -20,24 +20,6 @@ service:
       web_url: https://github.com/adnanh/webhook/releases/{{ version }}
       icon: https://raw.githubusercontent.com/adnanh/webhook/development/docs/logo/logo-128x128.png
 ```
-## argoproj/argo-cd
-Source: https://github.com/argoproj/argo-cd
-```yaml
-service:
-  argoproj/argo-cd:
-    latest_version:
-      type: github
-      url: argoproj/argo-cd
-      url_commands:
-      - type: regex
-        regex: v([0-9.]+)$
-    deployed_version:
-      url: https://argocd.example.io/api/version
-      regex: v([0-9.]+)
-    dashboard:
-      web_url: https://github.com/argoproj/argo-cd/releases/v{{ version }}
-      icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
-```
 
 ## ansible/awx
 Source: https://github.com/ansible/awx
@@ -53,6 +35,26 @@ service:
     dashboard:
       web_url: https://github.com/ansible/awx/releases/{{ version }}
       icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
+```
+
+## argoproj/argo-cd
+Source: https://github.com/argoproj/argo-cd
+```yaml
+service:
+  argoproj/argo-cd:
+    latest_version:
+      type: github
+      url: argoproj/argo-cd
+      url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    deployed_version:
+      url: https://argocd.example.io/api/version
+      json: Version
+      regex: v([0-9.]+)
+    dashboard:
+      web_url: https://github.com/argoproj/argo-cd/releases/v{{ version }}
+      icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 ```
 
 ## ansible/awx-operator

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -20,6 +20,24 @@ service:
       web_url: https://github.com/adnanh/webhook/releases/{{ version }}
       icon: https://raw.githubusercontent.com/adnanh/webhook/development/docs/logo/logo-128x128.png
 ```
+## argoproj/argo-cd
+Source: https://github.com/argoproj/argo-cd
+```yaml
+service:
+  argoproj/argo-cd:
+    latest_version:
+      type: github
+      url: argoproj/argo-cd
+      url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    deployed_version:
+      url: https://argocd.example.io/api/version
+      regex: v([0-9.]+)
+    dashboard:
+      web_url: https://github.com/argoproj/argo-cd/releases/v{{ version }}
+      icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
+```
 
 ## ansible/awx
 Source: https://github.com/ansible/awx


### PR DESCRIPTION
Add argoproh/argo-cd service example.

Service has a version endpoint that returns a JSON object like so:
```
{"Version":"v2.4.14+029be59"}
```

Regex: `v([0-9.]+)$` has picked up the versions just fine so far in the past 6 months.