### PR TITLE
Add `Sonarr/Sonarr` service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -37,6 +37,19 @@ service:
       icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
 ```
 
+## ansible/awx-operator
+Source: https://github.com/ansible/awx-operator
+```yaml
+service:
+  ansible/awx-operator:
+    latest_version:
+      type: github
+      url: ansible/awx-operator
+    dashboard:
+      web_url: https://github.com/ansible/awx-operator/releases/{{ version }}
+      icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
+```
+
 ## argoproj/argo-cd
 Source: https://github.com/argoproj/argo-cd
 ```yaml
@@ -55,19 +68,6 @@ service:
     dashboard:
       web_url: https://github.com/argoproj/argo-cd/releases/v{{ version }}
       icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
-```
-
-## ansible/awx-operator
-Source: https://github.com/ansible/awx-operator
-```yaml
-service:
-  ansible/awx-operator:
-    latest_version:
-      type: github
-      url: ansible/awx-operator
-    dashboard:
-      web_url: https://github.com/ansible/awx-operator/releases/{{ version }}
-      icon: https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg
 ```
 
 ## dani-garcia/vaultwarden

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -769,7 +769,7 @@ service:
 ## Sonarr/Sonarr
 Source: https://github.com/Sonarr/Sonarr
 
-- deployed_version - Requires an `API_KEY` which can be retrieved at `General/Security/API Key`
+- deployed_version - Requires an `API_KEY` which can be retrieved at `Settings/General/Security/API Key`
 ```yaml
 service:
   Sonarr/Sonarr:

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -766,6 +766,32 @@ service:
       icon: https://github.com/smallstep/docs/raw/main/static/graphics/logo-icon-white.svg
 ```
 
+## Sonarr/Sonarr
+Source: https://github.com/Sonarr/Sonarr
+
+- deployed_version - Requires an `API_KEY` which can be retrieved at `General/Security/API Key`
+```yaml
+service:
+  Sonarr/Sonarr:
+    options:
+      semantic_versioning: false
+    latest_version:
+      type: url
+      url: https://github.com/Sonarr/Sonarr/tags
+      url_commands:
+      - type: regex
+        regex: \/releases\/tag\/v?([0-9.]+)\"
+    deployed_version:
+      url: https://sonarr.example.io/api/v3/system/status
+      headers:
+      - key: X-Api-Key
+        value: <API_KEY>
+      json: version
+    dashboard:
+      web_url: https://sonarr.example.io/system/updates
+      icon: https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/256.png
+```
+
 ## thanos-io/thanos
 Source: https://github.com/thanos-io/thanos
 ```yaml


### PR DESCRIPTION
Swagger docs (For Radarr/Radarr which has very similar API): https://radarr.video/docs/api/#/System/get_api_v3_system_status


Example response:
```json
{
	"version": "3.0.9.1549",
	"buildTime": "2022-08-06T15:55:48Z",
	"isDebug": false,
	"isProduction": true,
	"isAdmin": false,
	"isUserInteractive": false,
	"startupPath": "/app/sonarr/bin",
	"appData": "/config",
	"osName": "ubuntu",
	"osVersion": "20.04",
	"isMonoRuntime": true,
	"isMono": true,
	"isLinux": true,
	"isOsx": false,
	"isWindows": false,
	"branch": "main",
	"authentication": "none",
	"sqliteVersion": "3.31.1",
	"urlBase": "",
	"runtimeVersion": "6.12.0.182",
	"runtimeName": "mono"
}
```
### A few points of note: 
- Sonarr/Sonarr does not maintain a CHANGELOG as explained in the [Github issue](https://github.com/Sonarr/Sonarr/issues/2059). The `web_url` instead directs to the user's own instance's `Updates` page which contains the changelog.
- There are no releases published on the repository, only tags, hence the custom logic in `latest_version`.
- This repository does not follow semantic versioning but instead follows something akin to the format: `major.minor.hotfix.build`