### PR TITLE
Add `Radarr/Radarr` service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -662,6 +662,32 @@ service:
       icon: https://raw.githubusercontent.com/pterodactyl/panel/develop/public/assets/svgs/pterodactyl.svg
 ```
 
+## Radarr/Radarr
+Source: https://github.com/Radarr/Radarr
+
+- deployed_version - Requires an `API_KEY` which can be retrieved at `Settings/General/Security/API Key`
+```yaml
+service:
+    Radarr/Radarr:
+    options:
+      semantic_versioning: false
+    latest_version:
+      type: github
+      url: Radarr/Radarr
+      url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    deployed_version:
+      url: https://radarr.example.io/api/v3/system/status
+      headers:
+      - key: X-Api-Key
+        value: <API_KEY>
+      json: version
+    dashboard:
+      web_url: https://github.com/Radarr/Radarr/releases/{{ version }}
+      icon: https://avatars.githubusercontent.com/u/25025331?s=200&v=4
+```
+
 ## rancher/rancher
 Source: https://github.com/rancher/rancher
 

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -668,7 +668,7 @@ Source: https://github.com/Radarr/Radarr
 - deployed_version - Requires an `API_KEY` which can be retrieved at `Settings/General/Security/API Key`
 ```yaml
 service:
-    Radarr/Radarr:
+  Radarr/Radarr:
     options:
       semantic_versioning: false
     latest_version:


### PR DESCRIPTION
Swagger docs: https://radarr.video/docs/api/#/System/get_api_v3_system_status


Example response:
```json
{
  "appName": "Radarr",
  "instanceName": "Radarr",
  "version": "4.2.4.6635",
  "buildTime": "2022-09-25T02:16:02Z",
  "isDebug": false,
  "isProduction": true,
  "isAdmin": false,
  "isUserInteractive": true,
  "startupPath": "/app/radarr/bin",
  "appData": "/config",
  "osName": "LinuxMusl",
  "isNetCore": true,
  "isLinux": true,
  "isOsx": false,
  "isWindows": false,
  "isDocker": false,
  "mode": "console",
  "branch": "master",
  "authentication": "none",
  "databaseType": "sqLite",
  "databaseVersion": "3.36.0",
  "migrationVersion": 214,
  "urlBase": "",
  "runtimeVersion": "6.0.8",
  "runtimeName": "netCore",
  "startTime": "2022-10-07T19:46:59Z",
  "packageVersion": "4.2.4.6635-ls153",
  "packageAuthor": "[linuxserver.io](https://linuxserver.io)",
  "packageUpdateMechanism": "docker"
}
```
### A few points of note: 
- Unlike `Sonarr/Sonarr` `Radarr/Radarr` maintains a well-defined CHANGELOG, so `web_url` is set to the releases page.
- This repository does not follow semantic versioning but instead follows something akin to the format: `major.minor.hotfix.build`