### PR TITLE
Add `jellyfin/jellyfin` service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -395,6 +395,25 @@ service:
       icon: https://github.com/influxdata/ui/raw/master/src/writeData/graphics/influxdb.svg
 ```
 
+## jellyfin/jellyfin
+Source: https://github.com/jellyfin/jellyfin
+```yaml
+service:
+  jellyfin/jellyfin:
+    latest_version:
+      type: github
+      url: jellyfin/jellyfin
+      url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    deployed_version:
+      url: https://jellyfin.example.io/System/Info/Public
+      json: Version
+    dashboard:
+      web_url: https://github.com/jellyfin/jellyfin/releases/v{{ version }}
+      icon: https://avatars.githubusercontent.com/u/45698031?s=200&v=4
+```
+
 ## jgraph/drawio
 Source: https://github.com/jgraph/drawio
 ```yaml


### PR DESCRIPTION
Swagger docs: https://api.jellyfin.org/#tag/System/operation/GetPublicSystemInfo

Example response:
```json
{
  "LocalAddress": "https://10.32.1.130:8920",
  "ServerName": "jellyfin-a3c1f87ea-lkjei",
  "Version": "10.8.5",
  "ProductName": "Jellyfin Server",
  "OperatingSystem": "Linux",
  "Id": "c88213349eec233df62b33706b077e55",
  "StartupWizardCompleted": true
}
```

Found that version information is actually available on a public, unauthenticated API endpoint. No API key is necessary.

Ref: Issue #26 