### PR TITLE
Add `Prowlarr/Prowlarr` service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -661,6 +661,33 @@ service:
       regex_content: prometheus-{{ version }}\.linux-amd64
 ```
 
+## Prowlarr/Prowlarr
+Source: https://github.com/Prowlarr/Prowlarr
+
+- deployed_version - Requires an `API_KEY` which can be retrieved at `Settings/General/Security/API Key`
+```yaml
+service:
+  Prowlarr/Prowlarr:
+    options:
+      semantic_versioning: false
+    latest_version:
+      type: github
+      url: Prowlarr/Prowlarr
+      url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+      use_prerelease: true
+    deployed_version:
+      url: https://prowlarr.example.io/api/v1/system/status
+      headers:
+      - key: X-Api-Key
+        value: <API_KEY>
+      json: version
+    dashboard:
+      web_url: https://github.com/Prowlarr/Prowlarr/releases/v{{ version }}
+      icon: https://avatars.githubusercontent.com/u/73049443?s=200&v=4
+```
+
 ## pterodactyl/panel
 Source: https://github.com/pterodactyl/panel
 ```yaml

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -723,7 +723,7 @@ service:
         value: <API_KEY>
       json: version
     dashboard:
-      web_url: https://github.com/Radarr/Radarr/releases/{{ version }}
+      web_url: https://github.com/Radarr/Radarr/releases/v{{ version }}
       icon: https://avatars.githubusercontent.com/u/25025331?s=200&v=4
 ```
 


### PR DESCRIPTION
Swagger docs: https://prowlarr.com/docs/api/#/System/get_api_v1_system_status

Example response:
```json
{
  "appName": "Prowlarr",
  "instanceName": "Prowlarr",
  "version": "0.4.6.1969",
  "buildTime": "2022-09-13T04:02:55Z",
  "isDebug": false,
  "isProduction": true,
  "isAdmin": false,
  "isUserInteractive": true,
  "startupPath": "/app/prowlarr/bin",
  "appData": "/config",
  "osName": "LinuxMusl",
  "isNetCore": true,
  "isMono": false,
  "isLinux": true,
  "isOsx": false,
  "isWindows": false,
  "isDocker": false,
  "mode": "console",
  "branch": "develop",
  "authentication": "none",
  "databaseType": "sqLite",
  "databaseVersion": "3.36.0",
  "migrationVersion": 21,
  "urlBase": "",
  "runtimeVersion": "6.0.6",
  "runtimeName": "netCore",
  "startTime": "2022-10-28T18:16:44Z",
  "packageVersion": "0.4.6.1969-ls69",
  "packageAuthor": "[linuxserver.io](https://www.linuxserver.io/)",
  "packageUpdateMechanism": "docker"
}
```

### Quirks
- `use_prerelease` is set to true since Prowlarr is technically still v0

### Fixes
- Fix Radarr `web_url`

