### PR TITLE
Add `morpheus65535/bazarr` service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -526,6 +526,30 @@ service:
       web_url: https://docs.mattermost.com/install/self-managed-changelog.html
 ```
 
+## morpheus65535/bazarr
+Source: https://github.com/morpheus65535/bazarr
+
+- deployed_version - Requires an `API_KEY` which can be retrieved at `Settings/General/Security/API Key`
+```yaml
+service:
+  morpheus65535/bazarr:
+    latest_version:
+      type: github
+      url: morpheus65535/bazarr
+      url_commands:
+      - type: regex
+        regex: v([0-9.]+)$
+    deployed_version:
+      url: https://bazarr.example.io/api/system/status
+      headers:
+      - key: X-API-KEY
+        value: <API_KEY>
+      json: data.bazarr_version
+    dashboard:
+      web_url: https://github.com/morpheus65535/bazarr/releases/v{{ version }}
+      icon: https://raw.githubusercontent.com/morpheus65535/bazarr/master/frontend/public/images/logo128.png
+```
+
 ## n8n-io/n8n
 Source: https://github.com/n8n-io/n8n
 ```yaml

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -404,8 +404,8 @@ service:
       type: github
       url: jellyfin/jellyfin
       url_commands:
-      - type: regex
-        regex: v([0-9.]+)$
+        - type: regex
+          regex: v([0-9.]+)$
     deployed_version:
       url: https://jellyfin.example.io/System/Info/Public
       json: Version
@@ -537,13 +537,13 @@ service:
       type: github
       url: morpheus65535/bazarr
       url_commands:
-      - type: regex
-        regex: v([0-9.]+)$
+        - type: regex
+          regex: v([0-9.]+)$
     deployed_version:
       url: https://bazarr.example.io/api/system/status
       headers:
-      - key: X-API-KEY
-        value: <API_KEY>
+        - key: X-API-KEY
+          value: <API_KEY>
       json: data.bazarr_version
     dashboard:
       web_url: https://github.com/morpheus65535/bazarr/releases/v{{ version }}
@@ -698,14 +698,14 @@ service:
       type: github
       url: Prowlarr/Prowlarr
       url_commands:
-      - type: regex
-        regex: v([0-9.]+)$
+        - type: regex
+          regex: v([0-9.]+)$
       use_prerelease: true
     deployed_version:
       url: https://prowlarr.example.io/api/v1/system/status
       headers:
-      - key: X-Api-Key
-        value: <API_KEY>
+        - key: X-Api-Key
+          value: <API_KEY>
       json: version
     dashboard:
       web_url: https://github.com/Prowlarr/Prowlarr/releases/v{{ version }}
@@ -765,13 +765,13 @@ service:
       type: github
       url: Radarr/Radarr
       url_commands:
-      - type: regex
-        regex: v([0-9.]+)$
+        - type: regex
+          regex: v([0-9.]+)$
     deployed_version:
       url: https://radarr.example.io/api/v3/system/status
       headers:
-      - key: X-Api-Key
-        value: <API_KEY>
+        - key: X-Api-Key
+          value: <API_KEY>
       json: version
     dashboard:
       web_url: https://github.com/Radarr/Radarr/releases/v{{ version }}
@@ -875,13 +875,13 @@ service:
       type: url
       url: https://github.com/Sonarr/Sonarr/tags
       url_commands:
-      - type: regex
-        regex: \/releases\/tag\/v?([0-9.]+)\"
+        - type: regex
+          regex: \/releases\/tag\/v?([0-9.]+)\"
     deployed_version:
       url: https://sonarr.example.io/api/v3/system/status
       headers:
-      - key: X-Api-Key
-        value: <API_KEY>
+        - key: X-Api-Key
+          value: <API_KEY>
       json: version
     dashboard:
       web_url: https://sonarr.example.io/system/updates


### PR DESCRIPTION
No swagger docs found but I grabbed the request/response from the developer console in Chrome

Example response:
```json
{
  "data": {
    "bazarr_config_directory": "/config", 
    "bazarr_directory": "/app/bazarr/bin", 
    "bazarr_version": "1.1.1", 
    "operating_system": "Linux-5.15.74-rockchip64-aarch64-with", 
    "package_version": "v1.1.1-ls167 by [linuxserver.io](https://linuxserver.io)", 
    "python_version": "3.9.5", 
    "radarr_version": "4.2.4.6635", 
    "sonarr_version": "3.0.9.1549", 
    "start_time": 1666981051.104633, 
    "timezone": "Asia/Singapore"
  }
}
```
