### PR TITLE
Fix home-assistant/core image URL

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -417,7 +417,7 @@ service:
           value: Bearer <API_Token>
     dashboard:
       web_url: https://www.home-assistant.io/latest-release-notes
-      icon: https://github.com/home-assistant/core/raw/dev/tests/components/image/logo.png
+      icon: https://github.com/home-assistant/core/raw/dev/tests/components/image_upload/logo.png
 ```
 
 ## influxdata/influxdb


### PR DESCRIPTION
Image URL changed in https://github.com/home-assistant/core/commit/80b357262795a57dc267a313064266fd2682ca74