### PR TITLE
fix: Grafana release notes

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -316,7 +316,7 @@ service:
       url: https://grafana.example.io/login
       regex: v([0-9.]+)\s\([0-9a-z]+\)
     dashboard:
-      web_url: https://grafana.com/docs/grafana/latest/release-notes/release-notes-{{ version | split:"." | join:"-"  }}
+      web_url: https://github.com/grafana/grafana/releases/tag/v{{ version }}
       icon: https://cdn.worldvectorlogo.com/logos/grafana.svg
 ```
 


### PR DESCRIPTION
Grafana no longer provides release notes in the documentation since v9.2.
https://grafana.com/docs/grafana/latest/release-notes/