### PR TITLE
Docker: Use folder mount for storage volume

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -72,7 +72,7 @@ services:
     image: releaseargus/argus:latest
     volumes:
       - /path/to/local/config.yml:/app/config.yml
-      - /path/to/storage/argus.db:/app/data/argus.db
+      - /path/to/storage/:/app/data/ # argus.db
     environment:
       ARGUS_UID: 911 # Optional UID override
       ARGUS_GID: 911 # Optional GID override


### PR DESCRIPTION
Only for `argus.db` for now, but doing this rather than the file bind mount prevents an anonymous bind mount for the volume. (Volume as we'd rather keep the db when updating)

#48