### PR TITLE
fix: Switch to alertmanager v2 API

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -703,8 +703,8 @@ service:
         - type: regex
           regex: v([0-9.]+)$
     deployed_version:
-      url: https://alertmanager.example.io/api/v1/status
-      json: data.versionInfo.version
+      url: https://alertmanager.example.io/api/v2/status
+      json: versionInfo.version
     dashboard:
       web_url: https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
       regex_content: alertmanager-{{ version }}\.linux-amd64.tar.gz


### PR DESCRIPTION
The deprecated alertmanager v1 API has been removed with the v0.27.0 release.
So a change to the new v2 API is required.

https://github.com/prometheus/alertmanager/releases/tag/v0.27.0