### PR TITLE
Add monitor documentation

### DIFF
--- a/content/en/docs/Help/_index.md
+++ b/content/en/docs/Help/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Help"
 linkTitle: "Help"
-weight: 4
+weight: 6
 description: ""
 ---
 

--- a/content/en/docs/Monitor/_index.md
+++ b/content/en/docs/Monitor/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Monitor"
+linkTitle: "Monitor"
+weight: 4
+description: "Monitor Argus"
+---
+

--- a/content/en/docs/Monitor/_index.md
+++ b/content/en/docs/Monitor/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Monitor"
 linkTitle: "Monitor"
-weight: 4
+weight: 5
 description: "Monitor Argus"
 ---
 

--- a/content/en/docs/Monitor/prometheus.md
+++ b/content/en/docs/Monitor/prometheus.md
@@ -1,0 +1,24 @@
+---
+title: "Prometheus"
+linkTitle: "Prometheus"
+weight: 4
+description: >
+  Argus monitoring with Prometheus
+---
+
+Argus exports Prometheus metrics on the `/metrics` endpoint. You can use the Prometheus exporter to monitor your Argus instance.
+
+## List of metrics
+
+Additional to the default Prometheus Go library metrics (refer to [prometheus/client_golang](https://github.com/prometheus/client_golang)), Argus exports the following metrics.
+
+| Metric | Description |
+| --- | --- |
+| `command_result_total` | Number of commands executed. |
+| `deployed_version_query_result_last` | Last deployed version query was successful(`0`=no,`1`=yes). |
+| `deployed_version_query_result_total` | Number of deployed version checks. |
+| `latest_version_is_deployed` | Latest version is the same as its deployed version (`0`=no, `1`=yes, `2`=approved, `3`=skipped) |
+| `latest_version_query_result_last` | Last latest version query was successful (`0`=no, `1`=yes, `2`=no_regex_match, `3`=semantic_version_fail, `4`=progressive_version_fail). |
+| `latest_version_query_result_total` | Number of latest version checks. |
+| `notify_result_total` | Number of notifications sent. |
+| `webhook_result_total` | Number of webhooks sent. |


### PR DESCRIPTION
# Why

Resolves: https://github.com/release-argus/Website/issues/83

First of all, thank you for this fantastic project!

We started using this on production but couldn't find any documents on monitoring Argus.
I glanced at the source code and realized that it exports Prometheus metrics. Amazing!

If this is documented, it would be great. 

Thank you in advance!