### PR TITLE
Immich use new API endpoint

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -591,7 +591,7 @@ service:
       type: github
       url: immich-app/immich
     deployed_version:
-      url: https://immich.example.io/api/server-info/about
+      url: https://immich.example.io/api/server/about
       json: version
       regex: ^v([0-9.]+)$
       headers:


### PR DESCRIPTION
Immich has deprecated and removed the API endpoint, which was used to get the current deployed version.