### PR TITLE
Fix front-matter dates and update to latest releases

### DIFF
--- a/content/en/docs/Legal/cookies.md
+++ b/content/en/docs/Legal/cookies.md
@@ -2,7 +2,7 @@
 title: "Cookies"
 linkTitle: "Cookies"
 weight: 3
-date: 2022-3-22
+date: 2022-03-22
 description: >
   Last updated March 22, 2022
 #hide_summary: true

--- a/content/en/docs/Legal/disclaimer.md
+++ b/content/en/docs/Legal/disclaimer.md
@@ -2,7 +2,7 @@
 title: "Disclaimer"
 linkTitle: "Disclaimer"
 weight: 3
-date: 2022-3-22
+date: 2022-03-22
 description: >
   Last updated March 22, 2022
 #hide_summary: true

--- a/content/en/docs/Legal/terms-and-conditions.md
+++ b/content/en/docs/Legal/terms-and-conditions.md
@@ -2,7 +2,7 @@
 title: "Terms & Conditions"
 linkTitle: "Terms & Conditions"
 weight: 3
-date: 2022-3-22
+date: 2022-03-22
 description: >
   Last updated March 22, 2022
 #hide_summary: true

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/release-argus/Website
 go 1.18
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
-	github.com/divinerites/plausible-hugo v1.20.0 // indirect
-	github.com/google/docsy v0.10.0 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de // indirect
+	github.com/divinerites/plausible-hugo v1.21.1 // indirect
+	github.com/google/docsy v0.11.0 // indirect
 	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de h1:JvHOfdSqvArF+7cffH9oWU8oLhn6YFYI60Pms8M/6tI=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/divinerites/plausible-hugo v1.20.0 h1:nkoQ/5/ti2nRF8DRiErEemOb1/EAbViUL05aSbiiRuU=
 github.com/divinerites/plausible-hugo v1.20.0/go.mod h1:cxr+YB3FUwbLon8KCs4pV4Ankbkq6lJxTQUpNb5KqPo=
+github.com/divinerites/plausible-hugo v1.21.1 h1:ZTWwjhZ0PmLMacCVGlcGiYFEZW7VaYE767tchDskOug=
+github.com/divinerites/plausible-hugo v1.21.1/go.mod h1:cxr+YB3FUwbLon8KCs4pV4Ankbkq6lJxTQUpNb5KqPo=
 github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
 github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
+github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
- `YYYY-MM-DD` instead of `YYYY-M-D`
- bump FortAwesome/Font-Awesome from v0.0.0-20240402185447-c0f460dca7f7 to v0.0.0-20240716171331-37eff7fa00de
- bump divinerites/plausible-hugo from v1.20.0 to v1.21.1
- bump google/docsy from v0.10.0 to v0.11.0